### PR TITLE
Fix Laravel tests by providing APP_KEY

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:da0RlgQN1Cd7gGdMQwkp6tfI/t6gKJr/uZ8PqnXLaqs="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>


### PR DESCRIPTION
## Summary
- add `APP_KEY` variable to phpunit.xml so tests have an encryption key

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6840e4517ae4832783777d7deecab924